### PR TITLE
WASM wrapper for derived ExplorerFindable::process_explorer_response();

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm-bindgen                        = "0.2.65"
 blake2b_simd                        = "0.5.11"
 base16                              = "0.2.1"
 json                                = "0.12.4"
-ergo_headless_dapp_framework_derive= { version = "^0.1.0" path = "./ergo-headless-dapp-framework-derive" }
+ergo_headless_dapp_framework_derive= { version = "^0.1.0", path = "./ergo-headless-dapp-framework-derive" }
 
 
 [package.metadata.wasm-pack.profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm-bindgen                        = "0.2.65"
 blake2b_simd                        = "0.5.11"
 base16                              = "0.2.1"
 json                                = "0.12.4"
-ergo_headless_dapp_framework_derive = "0.1.1"
+ergo_headless_dapp_framework_derive= { version = "^0.1.0" path = "./ergo-headless-dapp-framework-derive" }
 
 
 [package.metadata.wasm-pack.profile.release]

--- a/ergo-headless-dapp-framework-derive/src/lib.rs
+++ b/ergo-headless-dapp-framework-derive/src/lib.rs
@@ -60,12 +60,24 @@ fn impl_specified_box(ast: &syn::DeriveInput) -> TokenStream {
 
         #[wasm_bindgen]
         impl #name {
+
             #[wasm_bindgen]
             pub fn w_process_explorer_response(explorer_response_body: &str)
                 -> std::result::Result<Vec<JsValue>, JsValue> {
                 let boxes = Self::process_explorer_response(explorer_response_body)
                                 .map_err(|err| JsValue::from_str(&format!("{}", err)))?;
                 Ok(boxes.into_iter().map(JsValue::from).collect())
+            }
+
+            #[wasm_bindgen]
+            pub fn w_explorer_endpoint(explorer_api_url: &str) -> std::result::Result<String, JsValue> {
+                Self::box_spec().explorer_endpoint(explorer_api_url)
+                                .map_err(|err| JsValue::from_str(&format!("{}", err)))
+            }
+
+            #[wasm_bindgen]
+            pub fn w_box_spec() -> BoxSpec {
+                Self::box_spec()
             }
         }
 

--- a/ergo-headless-dapp-framework-derive/src/lib.rs
+++ b/ergo-headless-dapp-framework-derive/src/lib.rs
@@ -57,6 +57,17 @@ fn impl_specified_box(ast: &syn::DeriveInput) -> TokenStream {
             }
         }
 
+
+        #[wasm_bindgen]
+        impl #name {
+            pub fn w_process_explorer_response(explorer_response_body: &str)
+                -> std::result::Result<Vec<JsValue>, JsValue> {
+                let boxes = Self::process_explorer_response(explorer_response_body)
+                                .map_err(|err| JsValue::from_str(&format!("{}", err)))?;
+                Ok(boxes.into_iter().map(JsValue::from).collect())
+            }
+        }
+
     };
     gen.into()
 }

--- a/ergo-headless-dapp-framework-derive/src/lib.rs
+++ b/ergo-headless-dapp-framework-derive/src/lib.rs
@@ -60,6 +60,7 @@ fn impl_specified_box(ast: &syn::DeriveInput) -> TokenStream {
 
         #[wasm_bindgen]
         impl #name {
+            #[wasm_bindgen]
             pub fn w_process_explorer_response(explorer_response_body: &str)
                 -> std::result::Result<Vec<JsValue>, JsValue> {
                 let boxes = Self::process_explorer_response(explorer_response_body)


### PR DESCRIPTION
Exposes in WASM static `w_process_explorer_response`, `w_explorer_endpoint` and `w_box_spec` for any type that using  macros for deriving an implementation for `SpecifiedBox` trait.