### PR TITLE
Support for encoding Testnet and Mainnet addresses

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -140,23 +140,24 @@ pub fn deserialize_ergo_tree_constant(c: &Constant) -> Result<P2SAddressString> 
     Ok(encoder.address_to_str(&address))
 }
 
-// Takes an Ergo address and encodes it as a mainnet address
-// if it fails then it tries to recover by using the testnet prefix
-pub fn encode_address(address_str: &ErgoAddressString) -> Result<Address> {
+// Takes an Ergo address and transforms it into a mainnet address
+// if it fails then it tries to recover by assumming it is a testnet address
+pub fn parse_address(address_str: &ErgoAddressString) -> Result<Address> {
     let mainnet_encoder = AddressEncoder::new(NetworkPrefix::Mainnet);
     let testnet_encoder = AddressEncoder::new(NetworkPrefix::Testnet);
-    let address = mainnet_encoder
-        .parse_address_from_str(address_str);
+    let address = mainnet_encoder.parse_address_from_str(address_str);
     return match address {
         Ok(addr) => Ok(addr),
-        Err(error) => testnet_encoder.parse_address_from_str(address_str).map_err(|_| EncodingError::FailedToSerialize(address_str.to_string()))
+        Err(error) => testnet_encoder
+            .parse_address_from_str(address_str)
+            .map_err(|_| EncodingError::FailedToSerialize(address_str.to_string())),
     };
 }
 
 /// Takes an Ergo address (either P2PK or P2S) as a Base58 String and returns
 /// the `ErgoTree` if it is a valid address.
 pub fn address_string_to_ergo_tree(address_str: &ErgoAddressString) -> Result<ErgoTree> {
-    let address = encode_address(address_str)?;
+    let address = parse_address(address_str)?;
     let ergo_tree = address
         .script()
         .map_err(|_| EncodingError::FailedToSerialize(address_str.to_string()))?;

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -140,13 +140,23 @@ pub fn deserialize_ergo_tree_constant(c: &Constant) -> Result<P2SAddressString> 
     Ok(encoder.address_to_str(&address))
 }
 
+// Takes an Ergo address and encodes it as a mainnet address
+// if it fails then it tries to recover by using the testnet prefix
+pub fn encode_address(address_str: &ErgoAddressString) -> Result<Address> {
+    let mainnet_encoder = AddressEncoder::new(NetworkPrefix::Mainnet);
+    let testnet_encoder = AddressEncoder::new(NetworkPrefix::Testnet);
+    let address = mainnet_encoder
+        .parse_address_from_str(address_str);
+    return match address {
+        Ok(addr) => Ok(addr),
+        Err(error) => testnet_encoder.parse_address_from_str(address_str).map_err(|_| EncodingError::FailedToSerialize(address_str.to_string()))
+    };
+}
+
 /// Takes an Ergo address (either P2PK or P2S) as a Base58 String and returns
 /// the `ErgoTree` if it is a valid address.
 pub fn address_string_to_ergo_tree(address_str: &ErgoAddressString) -> Result<ErgoTree> {
-    let encoder = AddressEncoder::new(NetworkPrefix::Mainnet);
-    let address = encoder
-        .parse_address_from_str(address_str)
-        .map_err(|_| EncodingError::FailedToSerialize(address_str.to_string()))?;
+    let address = encode_address(address_str)?;
     let ergo_tree = address
         .script()
         .map_err(|_| EncodingError::FailedToSerialize(address_str.to_string()))?;


### PR DESCRIPTION
## Why do we need this PR?

Currently passing testnet addresses results in `FailedToSerialize` errors. This PR makes it so that we can handle both Testnet and Mainnet address.

There are multiple places in this lib where similar changes have to be added so this is just kicking off this effort.